### PR TITLE
Make Python code compliant with PEP8 and PEP257

### DIFF
--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -1,5 +1,5 @@
 #
-# TestRail API binding for Python 2.x (API v2, available since 
+# TestRail API binding for Python 2.x (API v2, available since
 # TestRail 3.0)
 #
 # Learn more:

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -73,7 +73,7 @@ class APIClient:
         else:
             result = {}
 
-        if e != None:
+        if e is not None:
             if result and 'error' in result:
                 error = '"' + result['error'] + '"'
             else:

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -10,7 +10,9 @@
 # Copyright Gurock Software GmbH. See license.md for details.
 #
 
-import urllib2, json, base64
+import base64
+import json
+import urllib2
 
 class APIClient:
     def __init__(self, base_url):

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -1,14 +1,14 @@
-#
-# TestRail API binding for Python 2.x (API v2, available since
-# TestRail 3.0)
-#
-# Learn more:
-#
-# http://docs.gurock.com/testrail-api2/start
-# http://docs.gurock.com/testrail-api2/accessing
-#
-# Copyright Gurock Software GmbH. See license.md for details.
-#
+"""TestRail API binding for Python 2.x.
+
+(API v2, available since TestRail 3.0)
+
+Learn more:
+
+http://docs.gurock.com/testrail-api2/start
+http://docs.gurock.com/testrail-api2/accessing
+
+Copyright Gurock Software GmbH. See license.md for details.
+"""
 
 import base64
 import json
@@ -23,34 +23,28 @@ class APIClient:
             base_url += '/'
         self.__url = base_url + 'index.php?/api/v2/'
 
-    #
-    # Send Get
-    #
-    # Issues a GET request (read) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. get_case/1)
-    #
     def send_get(self, uri):
+        """Issue a GET request (read) against the API.
+
+        Args:
+            uri: The API method to call, including parameters, e.g. get_case/1.
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('GET', uri, None)
 
-    #
-    # Send POST
-    #
-    # Issues a POST request (write) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. add_case/1)
-    # data                The data to submit as part of the request (as
-    #                     Python dict, strings must be UTF-8 encoded)
-    #
     def send_post(self, uri, data):
+        """Issue a POST request (write) against the API.
+
+        Args:
+            uri: The API method to call, including parameters, e.g. add_case/1.
+            data: The data to submit as part of the request (as a Python dict;
+                strings must be UTF-8 encoded)
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('POST', uri, data)
 
     def __send_request(self, method, uri, data):

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -14,6 +14,7 @@ import base64
 import json
 import urllib2
 
+
 class APIClient:
     def __init__(self, base_url):
         self.user = ''
@@ -81,6 +82,7 @@ class APIClient:
                 (e.code, error))
 
         return result
+
 
 class APIError(Exception):
     pass

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -79,7 +79,7 @@ class APIClient:
             else:
                 error = 'No additional error message received'
             raise APIError('TestRail API returned HTTP %s (%s)' %
-                (e.code, error))
+                           (e.code, error))
 
         return result
 

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -13,72 +13,72 @@
 import urllib2, json, base64
 
 class APIClient:
-	def __init__(self, base_url):
-		self.user = ''
-		self.password = ''
-		if not base_url.endswith('/'):
-			base_url += '/'
-		self.__url = base_url + 'index.php?/api/v2/'
+    def __init__(self, base_url):
+        self.user = ''
+        self.password = ''
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.__url = base_url + 'index.php?/api/v2/'
 
-	#
-	# Send Get
-	#
-	# Issues a GET request (read) against the API and returns the result
-	# (as Python dict).
-	#
-	# Arguments:
-	#
-	# uri                 The API method to call including parameters
-	#                     (e.g. get_case/1)
-	#
-	def send_get(self, uri):
-		return self.__send_request('GET', uri, None)
+    #
+    # Send Get
+    #
+    # Issues a GET request (read) against the API and returns the result
+    # (as Python dict).
+    #
+    # Arguments:
+    #
+    # uri                 The API method to call including parameters
+    #                     (e.g. get_case/1)
+    #
+    def send_get(self, uri):
+        return self.__send_request('GET', uri, None)
 
-	#
-	# Send POST
-	#
-	# Issues a POST request (write) against the API and returns the result
-	# (as Python dict).
-	#
-	# Arguments:
-	#
-	# uri                 The API method to call including parameters
-	#                     (e.g. add_case/1)
-	# data                The data to submit as part of the request (as
-	#                     Python dict, strings must be UTF-8 encoded)
-	#
-	def send_post(self, uri, data):
-		return self.__send_request('POST', uri, data)
+    #
+    # Send POST
+    #
+    # Issues a POST request (write) against the API and returns the result
+    # (as Python dict).
+    #
+    # Arguments:
+    #
+    # uri                 The API method to call including parameters
+    #                     (e.g. add_case/1)
+    # data                The data to submit as part of the request (as
+    #                     Python dict, strings must be UTF-8 encoded)
+    #
+    def send_post(self, uri, data):
+        return self.__send_request('POST', uri, data)
 
-	def __send_request(self, method, uri, data):
-		url = self.__url + uri
-		request = urllib2.Request(url)
-		if (method == 'POST'):
-			request.add_data(json.dumps(data))
-		auth = base64.b64encode('%s:%s' % (self.user, self.password))
-		request.add_header('Authorization', 'Basic %s' % auth)
-		request.add_header('Content-Type', 'application/json')
+    def __send_request(self, method, uri, data):
+        url = self.__url + uri
+        request = urllib2.Request(url)
+        if (method == 'POST'):
+            request.add_data(json.dumps(data))
+        auth = base64.b64encode('%s:%s' % (self.user, self.password))
+        request.add_header('Authorization', 'Basic %s' % auth)
+        request.add_header('Content-Type', 'application/json')
 
-		e = None
-		try:
-			response = urllib2.urlopen(request).read()
-		except urllib2.HTTPError as e:
-			response = e.read()
+        e = None
+        try:
+            response = urllib2.urlopen(request).read()
+        except urllib2.HTTPError as e:
+            response = e.read()
 
-		if response:
-			result = json.loads(response)
-		else:
-			result = {}
+        if response:
+            result = json.loads(response)
+        else:
+            result = {}
 
-		if e != None:
-			if result and 'error' in result:
-				error = '"' + result['error'] + '"'
-			else:
-				error = 'No additional error message received'
-			raise APIError('TestRail API returned HTTP %s (%s)' % 
-				(e.code, error))
+        if e != None:
+            if result and 'error' in result:
+                error = '"' + result['error'] + '"'
+            else:
+                error = 'No additional error message received'
+            raise APIError('TestRail API returned HTTP %s (%s)' %
+                (e.code, error))
 
-		return result
+        return result
 
 class APIError(Exception):
-	pass
+    pass

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -86,7 +86,7 @@ class APIClient:
             else:
                 error = 'No additional error message received'
             raise APIError('TestRail API returned HTTP %s (%s)' %
-                (e.code, error))
+                           (e.code, error))
 
         return result
 

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -10,8 +10,10 @@
 # Copyright Gurock Software GmbH. See license.md for details.
 #
 
-import urllib.request, urllib.error
-import json, base64
+import base64
+import json
+import urllib.error
+import urllib.request
 
 class APIClient:
     def __init__(self, base_url):

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -14,78 +14,78 @@ import urllib.request, urllib.error
 import json, base64
 
 class APIClient:
-	def __init__(self, base_url):
-		self.user = ''
-		self.password = ''
-		if not base_url.endswith('/'):
-			base_url += '/'
-		self.__url = base_url + 'index.php?/api/v2/'
+    def __init__(self, base_url):
+        self.user = ''
+        self.password = ''
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.__url = base_url + 'index.php?/api/v2/'
 
-	#
-	# Send Get
-	#
-	# Issues a GET request (read) against the API and returns the result
-	# (as Python dict).
-	#
-	# Arguments:
-	#
-	# uri                 The API method to call including parameters
-	#                     (e.g. get_case/1)
-	#
-	def send_get(self, uri):
-		return self.__send_request('GET', uri, None)
+    #
+    # Send Get
+    #
+    # Issues a GET request (read) against the API and returns the result
+    # (as Python dict).
+    #
+    # Arguments:
+    #
+    # uri                 The API method to call including parameters
+    #                     (e.g. get_case/1)
+    #
+    def send_get(self, uri):
+        return self.__send_request('GET', uri, None)
 
-	#
-	# Send POST
-	#
-	# Issues a POST request (write) against the API and returns the result
-	# (as Python dict).
-	#
-	# Arguments:
-	#
-	# uri                 The API method to call including parameters
-	#                     (e.g. add_case/1)
-	# data                The data to submit as part of the request (as
-	#                     Python dict, strings must be UTF-8 encoded)
-	#
-	def send_post(self, uri, data):
-		return self.__send_request('POST', uri, data)
+    #
+    # Send POST
+    #
+    # Issues a POST request (write) against the API and returns the result
+    # (as Python dict).
+    #
+    # Arguments:
+    #
+    # uri                 The API method to call including parameters
+    #                     (e.g. add_case/1)
+    # data                The data to submit as part of the request (as
+    #                     Python dict, strings must be UTF-8 encoded)
+    #
+    def send_post(self, uri, data):
+        return self.__send_request('POST', uri, data)
 
-	def __send_request(self, method, uri, data):
-		url = self.__url + uri
-		request = urllib.request.Request(url)
-		if (method == 'POST'):
-			request.data = bytes(json.dumps(data), 'utf-8')
-		auth = str(
-			base64.b64encode(
-				bytes('%s:%s' % (self.user, self.password), 'utf-8')
-			),
-			'ascii'
-		).strip()
-		request.add_header('Authorization', 'Basic %s' % auth)
-		request.add_header('Content-Type', 'application/json')
+    def __send_request(self, method, uri, data):
+        url = self.__url + uri
+        request = urllib.request.Request(url)
+        if (method == 'POST'):
+            request.data = bytes(json.dumps(data), 'utf-8')
+        auth = str(
+            base64.b64encode(
+                bytes('%s:%s' % (self.user, self.password), 'utf-8')
+            ),
+            'ascii'
+        ).strip()
+        request.add_header('Authorization', 'Basic %s' % auth)
+        request.add_header('Content-Type', 'application/json')
 
-		e = None
-		try:
-			response = urllib.request.urlopen(request).read()
-		except urllib.error.HTTPError as ex:
-			response = ex.read()
-			e = ex
+        e = None
+        try:
+            response = urllib.request.urlopen(request).read()
+        except urllib.error.HTTPError as ex:
+            response = ex.read()
+            e = ex
 
-		if response:
-			result = json.loads(response.decode())
-		else:
-			result = {}
+        if response:
+            result = json.loads(response.decode())
+        else:
+            result = {}
 
-		if e != None:
-			if result and 'error' in result:
-				error = '"' + result['error'] + '"'
-			else:
-				error = 'No additional error message received'
-			raise APIError('TestRail API returned HTTP %s (%s)' % 
-				(e.code, error))
+        if e != None:
+            if result and 'error' in result:
+                error = '"' + result['error'] + '"'
+            else:
+                error = 'No additional error message received'
+            raise APIError('TestRail API returned HTTP %s (%s)' % 
+                (e.code, error))
 
-		return result
+        return result
 
 class APIError(Exception):
-	pass
+    pass

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -80,7 +80,7 @@ class APIClient:
         else:
             result = {}
 
-        if e != None:
+        if e is not None:
             if result and 'error' in result:
                 error = '"' + result['error'] + '"'
             else:

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -15,6 +15,7 @@ import json
 import urllib.error
 import urllib.request
 
+
 class APIClient:
     def __init__(self, base_url):
         self.user = ''
@@ -88,6 +89,7 @@ class APIClient:
                 (e.code, error))
 
         return result
+
 
 class APIError(Exception):
     pass

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -1,14 +1,15 @@
-#
-# TestRail API binding for Python 3.x (API v2, available since
-# TestRail 3.0)
-#
-# Learn more:
-#
-# http://docs.gurock.com/testrail-api2/start
-# http://docs.gurock.com/testrail-api2/accessing
-#
-# Copyright Gurock Software GmbH. See license.md for details.
-#
+"""TestRail API binding for Python 3.x.
+
+(API v2, available since TestRail 3.0)
+
+Learn more:
+
+http://docs.gurock.com/testrail-api2/start
+http://docs.gurock.com/testrail-api2/accessing
+
+
+Copyright Gurock Software GmbH. See license.md for details.
+"""
 
 import base64
 import json
@@ -24,34 +25,28 @@ class APIClient:
             base_url += '/'
         self.__url = base_url + 'index.php?/api/v2/'
 
-    #
-    # Send Get
-    #
-    # Issues a GET request (read) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. get_case/1)
-    #
     def send_get(self, uri):
+        """Issue a GET request (read) against the API.
+
+        Args:
+            uri: The API method to call, including parameters, e.g. get_case/1.
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('GET', uri, None)
 
-    #
-    # Send POST
-    #
-    # Issues a POST request (write) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. add_case/1)
-    # data                The data to submit as part of the request (as
-    #                     Python dict, strings must be UTF-8 encoded)
-    #
     def send_post(self, uri, data):
+        """Issue a POST request (write) against the API.
+
+        Args:
+            uri: The API method to call, including parameters, e.g. add_case/1.
+            data: The data to submit as part of the request (as a Python dict;
+                strings must be UTF-8 encoded)
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('POST', uri, data)
 
     def __send_request(self, method, uri, data):

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -1,5 +1,5 @@
 #
-# TestRail API binding for Python 3.x (API v2, available since 
+# TestRail API binding for Python 3.x (API v2, available since
 # TestRail 3.0)
 #
 # Learn more:
@@ -82,7 +82,7 @@ class APIClient:
                 error = '"' + result['error'] + '"'
             else:
                 error = 'No additional error message received'
-            raise APIError('TestRail API returned HTTP %s (%s)' % 
+            raise APIError('TestRail API returned HTTP %s (%s)' %
                 (e.code, error))
 
         return result


### PR DESCRIPTION
The Python code is currently not compliant with common standards like [PEP8](https://www.python.org/dev/peps/pep-0008/) (code style) and [PEP 257](https://www.python.org/dev/peps/pep-0257/) (docstring conventions). This pull request makes various non-functional changes to the code to rectify the situation.
