### PR TITLE
Make Python code compliant with PEP8 and PEP257 (mk2)

### DIFF
--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -99,5 +99,6 @@ class APIClient:
                     return {}
 
 
+
 class APIError(Exception):
     pass

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -1,15 +1,16 @@
-#
-# TestRail API binding for Python 2.x (API v2, available since
-# TestRail 3.0)
-# Compatible with TestRail 3.0 and later.
-#
-# Learn more:
-#
-# http://docs.gurock.com/testrail-api2/start
-# http://docs.gurock.com/testrail-api2/accessing
-#
-# Copyright Gurock Software GmbH. See license.md for details.
-#
+"""TestRail API binding for Python 2.x.
+
+(API v2, available since TestRail 3.0)
+
+Compatible with TestRail 3.0 and later.
+
+Learn more:
+
+http://docs.gurock.com/testrail-api2/start
+http://docs.gurock.com/testrail-api2/accessing
+
+Copyright Gurock Software GmbH. See license.md for details.
+"""
 
 import base64
 import json
@@ -25,39 +26,31 @@ class APIClient:
             base_url += '/'
         self.__url = base_url + 'index.php?/api/v2/'
 
-    #
-    # Send Get
-    #
-    # Issues a GET request (read) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. get_case/1)
-    #
-    # filepath            The path and file name for attachment download
-    #                     Used only for 'get_attachment/:attachment_id'
-    #
     def send_get(self, uri, filepath=None):
+        """Issue a GET request (read) against the API.
+
+        Args:
+            uri: The API method to call including parameters, e.g. get_case/1.
+            filepath: The path and file name for attachment download; used only
+                for 'get_attachment/:attachment_id'.
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('GET', uri, filepath)
 
-    #
-    # Send POST
-    #
-    # Issues a POST request (write) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. add_case/1)
-    # data                The data to submit as part of the request (as
-    #                     Python dict, strings must be UTF-8 encoded)
-    #                     If adding an attachment, must be the path
-    #                     to the file
-    #
     def send_post(self, uri, data):
+        """Issue a POST request (write) against the API.
+
+        Args:
+            uri: The API method to call, including parameters, e.g. add_case/1.
+            data: The data to submit as part of the request as a dict; strings
+                must be UTF-8 encoded. If adding an attachment, must be the
+                path to the file.
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('POST', uri, data)
 
     def __send_request(self, method, uri, data):

--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -11,9 +11,10 @@
 # Copyright Gurock Software GmbH. See license.md for details.
 #
 
-import requests
-import json
 import base64
+import json
+
+import requests
 
 
 class APIClient:

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -17,6 +17,7 @@ import json
 import requests
 
 
+
 class APIClient:
     def __init__(self, base_url):
         self.user = ''
@@ -102,6 +103,7 @@ class APIClient:
                     return response.json()
                 except: # Nothing to return
                     return {}
+
 
 
 class APIError(Exception):

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -1,15 +1,16 @@
-#
-# TestRail API binding for Python 3.x (API v2, available since
-# TestRail 3.0)
-# Compatible with TestRail 3.0 and later.
-#
-# Learn more:
-#
-# http://docs.gurock.com/testrail-api2/start
-# http://docs.gurock.com/testrail-api2/accessing
-#
-# Copyright Gurock Software GmbH. See license.md for details.
-#
+"""TestRail API binding for Python 3.x.
+
+(API v2, available since TestRail 3.0)
+
+Compatible with TestRail 3.0 and later.
+
+Learn more:
+
+http://docs.gurock.com/testrail-api2/start
+http://docs.gurock.com/testrail-api2/accessing
+
+Copyright Gurock Software GmbH. See license.md for details.
+"""
 
 import base64
 import json
@@ -26,39 +27,31 @@ class APIClient:
             base_url += '/'
         self.__url = base_url + 'index.php?/api/v2/'
 
-    #
-    # Send Get
-    #
-    # Issues a GET request (read) against the API and returns the result
-    # (as Python dict) or filepath if successful file download
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. get_case/1)
-    #
-    # filepath            The path and file name for attachment download
-    #                     Used only for 'get_attachment/:attachment_id'
-    #
     def send_get(self, uri, filepath=None):
+        """Issue a GET request (read) against the API.
+
+        Args:
+            uri: The API method to call including parameters, e.g. get_case/1.
+            filepath: The path and file name for attachment download; used only
+                for 'get_attachment/:attachment_id'.
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('GET', uri, filepath)
 
-    #
-    # Send POST
-    #
-    # Issues a POST request (write) against the API and returns the result
-    # (as Python dict).
-    #
-    # Arguments:
-    #
-    # uri                 The API method to call including parameters
-    #                     (e.g. add_case/1)
-    # data                The data to submit as part of the request (as
-    #                     Python dict, strings must be UTF-8 encoded)
-    #                     If adding an attachment, must be the path
-    #                     to the file
-    #
     def send_post(self, uri, data):
+        """Issue a POST request (write) against the API.
+
+        Args:
+            uri: The API method to call, including parameters, e.g. add_case/1.
+            data: The data to submit as part of the request as a dict; strings
+                must be UTF-8 encoded. If adding an attachment, must be the
+                path to the file.
+
+        Returns:
+            A dict containing the result of the request.
+        """
         return self.__send_request('POST', uri, data)
 
     def __send_request(self, method, uri, data):

--- a/python/3.x/testrail.py
+++ b/python/3.x/testrail.py
@@ -11,9 +11,10 @@
 # Copyright Gurock Software GmbH. See license.md for details.
 #
 
-import requests
-import json
 import base64
+import json
+
+import requests
 
 
 class APIClient:


### PR DESCRIPTION
The Python code is currently not compliant with common standards like [PEP8](https://www.python.org/dev/peps/pep-0008/) (code style) and [PEP 257](https://www.python.org/dev/peps/pep-0257/) (docstring conventions). This pull request makes various non-functional changes to the code to improve compliance with these standards.

This PR replaces #3, which was closed after the API code was substantially reworked.