### PR TITLE
Add option to use unsecure ssl connexion

### DIFF
--- a/python/2.x/testrail.py
+++ b/python/2.x/testrail.py
@@ -22,6 +22,7 @@ class APIClient:
     def __init__(self, base_url):
         self.user = ''
         self.password = ''
+        self.ssl_secure = True
         if not base_url.endswith('/'):
             base_url += '/'
         self.__url = base_url + 'index.php?/api/v2/'
@@ -56,21 +57,24 @@ class APIClient:
     def __send_request(self, method, uri, data):
         url = self.__url + uri
 
+        if not self.ssl_secure:
+            requests.packages.urllib3.disable_warnings()
+
         auth = base64.b64encode('%s:%s' % (self.user, self.password))
         headers = {'Authorization': 'Basic ' + auth}
 
         if method == 'POST':
             if uri[:14] == 'add_attachment':    # add_attachment API method
                 files = {'attachment': (open(data, 'rb'))}
-                response = requests.post(url, headers=headers, files=files)
+                response = requests.post(url, headers=headers, files=files, verify=self.ssl_secure)
                 files['attachment'].close()
             else:
                 headers['Content-Type'] = 'application/json'
                 payload = bytes(json.dumps(data))
-                response = requests.post(url, headers=headers, data=payload)
+                response = requests.post(url, headers=headers, data=payload, verify=self.ssl_secure)
         else:
             headers['Content-Type'] = 'application/json'
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, verify=self.ssl_secure)
 
         if response.status_code > 201:
             try:


### PR DESCRIPTION
Hi,

Title is quite self explanatory. We needed to be able to use unsecured ssl connection for testing purpose.

It's added to the lib as an optional argument. Default behavior should not be changed by these modifications.